### PR TITLE
✨Update Eternal9's Link

### DIFF
--- a/source/links.json
+++ b/source/links.json
@@ -126,7 +126,7 @@
         "desc": "我永远喜欢温迪"
     },
     {
-        "url": "https://omi.std.moe",
+        "url": "https://eternal9.net",
         "avatar": "https://i.imgtg.com/2022/11/24/4rBJL.jpg",
         "name": "Eternal9",
         "color": "#DC4437",


### PR DESCRIPTION
Domain update.

博主您好！本人的博客域名近日由 [https://omi.std.moe/](https://omi.std.moe/) 更换为 [https://eternal9.net](https://eternal9.net)，故申请更改。